### PR TITLE
Remove one unnecessary subtraction

### DIFF
--- a/lib/src/mention_tag_text_editing_controller.dart
+++ b/lib/src/mention_tag_text_editing_controller.dart
@@ -197,7 +197,7 @@ class MentionTagTextEditingController extends TextEditingController {
 
     if (indexMentionFromStart != -1) {
       final indexMentionStart = indexCursor - indexMentionFromStart;
-      _indexMentionEnd = (indexMentionStart + indexMentionFromStart) - 1;
+      _indexMentionEnd = indexCursor - 1;
 
       if (value.length == 1) return value.first;
 


### PR DESCRIPTION
## Proof

1. Substitute `indexMentionStart` value inside `_indexMentionEnd` equation:

```dart
final indexMentionStart = indexCursor - indexMentionFromStart;
_indexMentionEnd = (indexCursor - indexMentionFromStart + indexMentionFromStart) - 1;
``` 

2. Because subtraction and addition are in the same order of operations their parenthesis can be removed:

```dart
final indexMentionStart = indexCursor - indexMentionFromStart;
_indexMentionEnd = indexCursor - indexMentionFromStart + indexMentionFromStart - 1;
```

3. `indexMentionFromStart` can be canceled out:

```dart
final indexMentionStart = indexCursor - indexMentionFromStart;
_indexMentionEnd = indexCursor - 1;
```